### PR TITLE
Fix incorrect variable reference in negated constraint naming

### DIFF
--- a/printemps/model/model.h
+++ b/printemps/model/model.h
@@ -4000,7 +4000,7 @@ class Model {
                     *variable_ptrs[NEGATED_VARIABLE_NAME] +
                         *variable_ptrs["~" + NEGATED_VARIABLE_NAME] ==
                     1;
-                hard_constraint_proxy(i).set_name(
+                negated_variable_constraint_proxy(i).set_name(
                     "negated_variable_constraints_" + NEGATED_VARIABLE_NAME);
             }
         }


### PR DESCRIPTION
## Summary
Fixed a bug where the wrong variable reference was being used when setting the name of negated variable constraints.

## Key Changes
- Changed `hard_constraint_proxy(i)` to `negated_variable_constraint_proxy(i)` when setting the constraint name for negated variables
- This ensures the constraint name is set on the correct constraint object rather than a generic hard constraint proxy

## Details
The code was incorrectly using `hard_constraint_proxy(i)` to set the name of negated variable constraints. The fix uses the more specific `negated_variable_constraint_proxy(i)` reference, which properly targets the negated variable constraint being configured. This improves code correctness and clarity by ensuring the constraint naming operation is applied to the intended constraint object.

https://claude.ai/code/session_019YDVZkajGaxiG7Km3DZsbd