### PR TITLE
Add support for fixing variables to specified values

### DIFF
--- a/extra/pb_competition_2025/pb_competition_2025_solver.h
+++ b/extra/pb_competition_2025/pb_competition_2025_solver.h
@@ -160,6 +160,17 @@ class PBCompetition2025Solver {
             m_model.import_solution(INITIAL_SOLUTION);
         }
 
+        /**
+         * If the fixed variable file is given, the values of the variables will
+         * be fixed at the specified values.
+         */
+        if (!m_argparser.fixed_variable_file_name.empty()) {
+            const auto FIXED_VARIABLES_AND_VALUES =
+                printemps::helper::read_names_and_values(
+                    m_argparser.fixed_variable_file_name);
+            m_model.fix_variables(FIXED_VARIABLES_AND_VALUES);
+        }
+
         if (m_argparser.is_specified_iteration_max) {
             m_option.general.iteration_max = m_argparser.iteration_max;
         }

--- a/extra/pb_competition_2025/pb_competition_2025_solver_argparser.h
+++ b/extra/pb_competition_2025/pb_competition_2025_solver_argparser.h
@@ -17,6 +17,7 @@ struct PBCompetition2025SolverArgparserConstant {
 struct PBCompetition2025SolverArgparser {
     std::string pb_file_name;
     std::string initial_solution_file_name;
+    std::string fixed_variable_file_name;
 
     double iteration_max;
     double time_max;
@@ -37,6 +38,7 @@ struct PBCompetition2025SolverArgparser {
     inline void initialize(void) {
         this->pb_file_name.clear();
         this->initial_solution_file_name.clear();
+        this->fixed_variable_file_name.clear();
 
         this->iteration_max =
             option::GeneralOptionConstant::DEFAULT_ITERATION_MAX;
@@ -65,6 +67,7 @@ struct PBCompetition2025SolverArgparser {
                   << "[-j NUMBER_OF_THREADS] "
                   << "[-r SEED] "
                   << "[-i INITIAL_SOLUTION_FILE] "
+                  << "[-f FIXED_VARIABLE_FILE] "
                   << "opb_file" << std::endl;
         std::cout << std::endl;
         std::cout  //
@@ -90,6 +93,10 @@ struct PBCompetition2025SolverArgparser {
         std::cout  //
             << "  -i INITIAL_SOLUTION_FILE: Specify the file name of an "
                "initial solution."
+            << std::endl;
+        std::cout  //
+            << "  -f FIXED_VARIABLE_FILE: Specify the file name of fixed "
+               "variables and their values."
             << std::endl;
     }
 
@@ -117,6 +124,9 @@ struct PBCompetition2025SolverArgparser {
                 i += 2;
             } else if (args[i] == "-i") {
                 this->initial_solution_file_name = args[i + 1];
+                i += 2;
+            } else if (args[i] == "-f") {
+                this->fixed_variable_file_name = args[i + 1];
                 i += 2;
             } else {
                 this->pb_file_name = args[i];


### PR DESCRIPTION
## Summary
This PR adds functionality to fix variables to specified values during solver initialization. Users can now provide a file containing variable names and their fixed values, which will be applied to the model before optimization begins.

## Key Changes
- **Argument Parser**: Added `-f FIXED_VARIABLE_FILE` command-line option to specify a file containing fixed variables and their values
  - New `fixed_variable_file_name` field in `PBCompetition2025SolverArgparser` struct
  - Updated help text to document the new option
  - Added parsing logic to handle the `-f` flag

- **Solver Initialization**: Integrated fixed variable loading into the solver setup
  - After loading the initial solution (if provided), the solver now reads the fixed variables file
  - Uses `printemps::helper::read_names_and_values()` to parse the file
  - Applies fixed variables to the model via `m_model.fix_variables()`

## Implementation Details
- The fixed variable file processing is conditional and only executes if a file name is provided
- Fixed variables are applied after initial solution loading, allowing them to override or complement initial values
- The implementation follows the existing pattern used for initial solution file handling

https://claude.ai/code/session_0161rMjnCBqqkEwV7CBC5KWG