### PR TITLE
Add OPB/WBO solution augmentation for fixed variables

### DIFF
--- a/printemps/standalone/standalone.h
+++ b/printemps/standalone/standalone.h
@@ -164,9 +164,12 @@ class Standalone {
          * be fixed at the specified values.
          */
         if (!m_argparser.fixed_variable_file_name.empty()) {
-            const auto FIXED_VARIABLES_AND_VALUES =
+            auto FIXED_VARIABLES_AND_VALUES =
                 printemps::helper::read_names_and_values(
                     m_argparser.fixed_variable_file_name);
+            if (EXTENSION == "opb" || EXTENSION == "wbo") {
+                m_opb.augment_solution(FIXED_VARIABLES_AND_VALUES);
+            }
             m_model.fix_variables(FIXED_VARIABLES_AND_VALUES);
         }
 


### PR DESCRIPTION
## Summary
Added support for augmenting OPB/WBO solutions when fixed variables are specified via a file, ensuring that fixed variable assignments are properly reflected in the solver's internal state for these problem formats.

## Key Changes
- Changed `FIXED_VARIABLES_AND_VALUES` from `const auto` to `auto` to allow reuse of the variable
- Added conditional logic to call `m_opb.augment_solution()` when processing OPB or WBO format files with fixed variables
- The augmentation occurs before the general model variable fixing, ensuring format-specific handling is applied

## Implementation Details
The fix ensures that when users provide a fixed variables file for OPB or WBO problems, the solver's internal OPB/WBO representation is updated with these fixed values through the `augment_solution()` method, maintaining consistency between the model state and the format-specific solver state.

https://claude.ai/code/session_01RoxE2kQWZoJLkesvTCtEZZ